### PR TITLE
MCOL-1774 - enclose and escape character support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sudo make package
 ```
 
 ### MSI
-Currently only remote cpimport / mcsimport can be built and used on Windows.
+Currently only mcsimport can be built and used on Windows.
 
 To compile it you first have to install the Windows version of mcsapi and set the environment variable `MCSAPI_INSTALL_DIR` to its top level installation directory.
 
@@ -74,7 +74,7 @@ mkdir build && cd build
 cmake -DTEST_RUNNER=ON -G "Visual Studio 14 2015 Win64" ..
 cmake --build . --config RelWithDebInfo --target package
 ctest -C RelWithDebInfo -V
-signtool.exe sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a "MariaDB ColumnStore Remote CpImport-*-x64.msi"
+signtool.exe sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a "MariaDB ColumnStore mcsimport-*-x64.msi"
 ```
 **NOTE**  
 For testing you have to set the environment variables `MCSAPI_CS_TEST_IP`, `MCSAPI_CS_TEST_PASSWORD`, `MCSAPI_CS_TEST_USER`, and `COLUMNSTORE_INSTALL_DIR`. Please see the additional instructions in mcsimport's sub-directory.

--- a/mcsimport/README.md
+++ b/mcsimport/README.md
@@ -1,4 +1,4 @@
-# MariaDB ColumnStore remote cpimport - mcsimport
+# MariaDB ColumnStore mcsimport
 
 This tool imports data from a csv file into a remote ColumnStore instance utilizing the Bulk Write SDK.
 
@@ -54,12 +54,12 @@ mkdir build && cd build
 cmake ../mariadb-columnstore-data-adapters -DBACKUPRESTORE=OFF -DMONITORING=OFF -DREMOTE_CPIMPORT=ON -G "Visual Studio 14 2015 Win64" -DTEST_RUNNER=ON
 cmake --build . --config RelWithDebInfo --target package
 ctest -C RelWithDebInfo -V
-signtool.exe sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a "MariaDB ColumnStore Remote CpImport*-x64.msi"
+signtool.exe sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a "MariaDB ColumnStore mcsimport-*-x64.msi"
 ```
 
 ## Usage
 ```shell
-mcsimport database table input_file [-m mapping_file] [-c Columnstore.xml] [-d delimiter] [-df date_format] [-default_non_mapped]
+mcsimport database table input_file [-m mapping_file] [-c Columnstore.xml] [-d delimiter] [-df date_format] [-default_non_mapped] [-E enclose_by_character] [-C escape_character] [-header]
 ```
 
 ### -m mapping_file
@@ -107,7 +107,16 @@ The default delimiter of the CSV input file is a comma `,` and can be changed th
 By default mcsimport uses `YYYY-MM-DD HH:MM:SS` as input date format. An individual global date format can be specified via the command line parameter -df using the [strptime] format. Column specific input date formats can be defined in the mapping file and overwrite the global date format.
 
 ### -default_non_mapped
-Remote cpimport needs to inject values for all columnstore columns. In order to use the columnstore column's default values for all non mapped target columns the global parameter `default_non_mapped` can be used. Target column specific default values in the mapping file overwrite the global default values of this parameter.
+mcsimport needs to inject values for all columnstore columns. In order to use the columnstore column's default values for all non mapped target columns the global parameter `default_non_mapped` can be used. Target column specific default values in the mapping file overwrite the global default values of this parameter.
+
+### -E enclose_by_character
+By default mcsimport uses the double-quote character `"` as enclosing character. It can be changed through the command line parameter -E. The enclosing character's length is limited to 1.
+
+### -C escape_character
+By default mcsimport uses the double-quote character `"` as escaping character. It can be changed through the command line parameter -C. The escaping character's length is limited to 1.
+
+### -header
+Choose this flag to ignore the first line of the input CSV file as header. (It won't be injected)
 
 [mcsapi]: https://github.com/mariadb-corporation/mariadb-columnstore-api
 [yaml-cpp]: https://github.com/jbeder/yaml-cpp

--- a/mcsimport/test/README.md
+++ b/mcsimport/test/README.md
@@ -83,4 +83,10 @@ Here a list of executed tests by the test suite and short explanation.
 | special combination explicit inject     | test using a complex explicit mapping file and global parameter flags                               | special_2          |
 | special combination hybrid inject       | test using a complex hybrid of implicit and later explicit mapping, defaults and global paramters   | special_3          |
 | alternative columnstore configuration   | tests the usage of an alternative columnstore configuration submitted via command line parameter    | alt_columstore_con |
+| enclosesure test with default parameter | tests the injection with the default enclosing and escaping character (")                           | enclose_1          |
+| encl. test with special escape char.    | tests the injection with the default enclosing char (") and special escape char (/)                 | enclose_2          |
+| encl. test with special encl. char.     | tests the injection with a special enclosing char (+) and default escape char (")                   | enclose_3          |
+| encl. test with sp encl. and esc. char. | tests the injection with a special enclosing char (+) and special escape char (\)                   | enclose_4          |
+| test with sp encl., esc. char. and deli | tests the injection with a special enclosing char (+), escape char (\) and delimiter (|)            | enclose_5          |
+| tests if the header line is ignored     | tests if the header line is ignored when chosen by option                                           | header_1           |
 

--- a/mcsimport/test/README.md
+++ b/mcsimport/test/README.md
@@ -86,7 +86,7 @@ Here a list of executed tests by the test suite and short explanation.
 | enclosesure test with default parameter | tests the injection with the default enclosing and escaping character (")                           | enclose_1          |
 | encl. test with special escape char.    | tests the injection with the default enclosing char (") and special escape char (/)                 | enclose_2          |
 | encl. test with special encl. char.     | tests the injection with a special enclosing char (+) and default escape char (")                   | enclose_3          |
-| encl. test with sp encl. and esc. char. | tests the injection with a special enclosing char (+) and special escape char (\)                   | enclose_4          |
-| test with sp encl., esc. char. and deli | tests the injection with a special enclosing char (+), escape char (\) and delimiter (|)            | enclose_5          |
+| encl. test with sp encl. and esc. char. | tests the injection with a special enclosing char (+) and special escape char (\\)                   | enclose_4          |
+| test with sp encl., esc. char. and deli | tests the injection with a special enclosing char (+), escape char (\\) and delimiter (\|)            | enclose_5          |
 | tests if the header line is ignored     | tests if the header line is ignored when chosen by option                                           | header_1           |
 

--- a/mcsimport/test/enclose_1/DDL.sql
+++ b/mcsimport/test/enclose_1/DDL.sql
@@ -1,0 +1,1 @@
+CREATE TABLE IF NOT EXISTS mcsimport_test_enclose_1 (id int, v varchar(16), i2 int) engine=columnstore

--- a/mcsimport/test/enclose_1/config.yaml
+++ b/mcsimport/test/enclose_1/config.yaml
@@ -1,0 +1,17 @@
+# required test parameter
+name: enclosesure test with default parameter
+expected_exit_value: 0
+
+# required mcsimport command line paramter
+table: mcsimport_test_enclose_1
+# database is defined by test.py
+# input file input.csv will be used if present in test directory
+
+# optional mcsimport command line parameter
+delimiter: 
+date_format: 
+default_non_mapped: #True, default False
+header: #True, default False
+enclosing_character: 
+escaping_character: 
+# mapping file mapping.yaml will be used if present in test directory

--- a/mcsimport/test/enclose_1/expected.csv
+++ b/mcsimport/test/enclose_1/expected.csv
@@ -1,0 +1,5 @@
+1,hello world,1
+2,"hello world",2
+3,"hello 
+world",
+4,"hello ""world""",4

--- a/mcsimport/test/enclose_1/input.csv
+++ b/mcsimport/test/enclose_1/input.csv
@@ -1,0 +1,5 @@
+1,hello world,1
+2,"hello world",2
+3,"hello 
+world",
+4,"hello ""world""",4

--- a/mcsimport/test/enclose_2/DDL.sql
+++ b/mcsimport/test/enclose_2/DDL.sql
@@ -1,0 +1,1 @@
+CREATE TABLE IF NOT EXISTS mcsimport_test_enclose_2 (id int, v varchar(16), i2 int) engine=columnstore

--- a/mcsimport/test/enclose_2/config.yaml
+++ b/mcsimport/test/enclose_2/config.yaml
@@ -1,0 +1,17 @@
+# required test parameter
+name: encl. test with special escape char.
+expected_exit_value: 0
+
+# required mcsimport command line paramter
+table: mcsimport_test_enclose_2
+# database is defined by test.py
+# input file input.csv will be used if present in test directory
+
+# optional mcsimport command line parameter
+delimiter: 
+date_format: 
+default_non_mapped: #True, default False
+header: #True, default False
+enclosing_character: 
+escaping_character: \
+# mapping file mapping.yaml will be used if present in test directory

--- a/mcsimport/test/enclose_2/expected.csv
+++ b/mcsimport/test/enclose_2/expected.csv
@@ -1,0 +1,5 @@
+1,hello world,1
+2,"hello world",2
+3,"hello 
+world",
+4,"hello ""world""",4

--- a/mcsimport/test/enclose_2/input.csv
+++ b/mcsimport/test/enclose_2/input.csv
@@ -1,0 +1,5 @@
+1,hello world,1
+2,"hello world",2
+3,"hello 
+world",
+4,"hello \"world\"",4

--- a/mcsimport/test/enclose_3/DDL.sql
+++ b/mcsimport/test/enclose_3/DDL.sql
@@ -1,0 +1,1 @@
+CREATE TABLE IF NOT EXISTS mcsimport_test_enclose_3 (id int, v varchar(16), i2 int) engine=columnstore

--- a/mcsimport/test/enclose_3/config.yaml
+++ b/mcsimport/test/enclose_3/config.yaml
@@ -1,0 +1,17 @@
+# required test parameter
+name: encl. test with special encl. char.
+expected_exit_value: 0
+
+# required mcsimport command line paramter
+table: mcsimport_test_enclose_3
+# database is defined by test.py
+# input file input.csv will be used if present in test directory
+
+# optional mcsimport command line parameter
+delimiter: 
+date_format: 
+default_non_mapped: #True, default False
+header: #True, default False
+enclosing_character: +
+escaping_character: 
+# mapping file mapping.yaml will be used if present in test directory

--- a/mcsimport/test/enclose_3/expected.csv
+++ b/mcsimport/test/enclose_3/expected.csv
@@ -1,0 +1,5 @@
+1,hello world,1
+2,"hello world",2
+3,"hello 
+world",
+4,"hello +world+",4

--- a/mcsimport/test/enclose_3/input.csv
+++ b/mcsimport/test/enclose_3/input.csv
@@ -1,0 +1,5 @@
+1,hello world,1
+2,+hello world+,2
+3,+hello 
+world+,
+4,+hello "+world"++,4

--- a/mcsimport/test/enclose_4/DDL.sql
+++ b/mcsimport/test/enclose_4/DDL.sql
@@ -1,0 +1,1 @@
+CREATE TABLE IF NOT EXISTS mcsimport_test_enclose_4 (id int, v varchar(16), i2 int) engine=columnstore

--- a/mcsimport/test/enclose_4/config.yaml
+++ b/mcsimport/test/enclose_4/config.yaml
@@ -1,0 +1,17 @@
+# required test parameter
+name: encl. test with sp encl. and esc. char.
+expected_exit_value: 0
+
+# required mcsimport command line paramter
+table: mcsimport_test_enclose_4
+# database is defined by test.py
+# input file input.csv will be used if present in test directory
+
+# optional mcsimport command line parameter
+delimiter: 
+date_format: 
+default_non_mapped: #True, default False
+header: #True, default False
+enclosing_character: +
+escaping_character: \
+# mapping file mapping.yaml will be used if present in test directory

--- a/mcsimport/test/enclose_4/expected.csv
+++ b/mcsimport/test/enclose_4/expected.csv
@@ -1,0 +1,7 @@
+1,hello world,1
+2,"hello world",2
+3,"hello 
+world",
+4,"hello +world+",4
+5,\,5
+6,\,6

--- a/mcsimport/test/enclose_4/input.csv
+++ b/mcsimport/test/enclose_4/input.csv
@@ -1,0 +1,7 @@
+1,hello world,1
+2,+hello world+,2
+3,+hello 
+world+,
+4,+hello \+world\++,4
+5,\,5
+6,+\\+,6

--- a/mcsimport/test/enclose_5/DDL.sql
+++ b/mcsimport/test/enclose_5/DDL.sql
@@ -1,0 +1,1 @@
+CREATE TABLE IF NOT EXISTS mcsimport_test_enclose_5 (id int, v varchar(16), i2 int) engine=columnstore

--- a/mcsimport/test/enclose_5/config.yaml
+++ b/mcsimport/test/enclose_5/config.yaml
@@ -1,0 +1,17 @@
+# required test parameter
+name: test with sp encl., esc. char. and deli
+expected_exit_value: 0
+
+# required mcsimport command line paramter
+table: mcsimport_test_enclose_5
+# database is defined by test.py
+# input file input.csv will be used if present in test directory
+
+# optional mcsimport command line parameter
+delimiter: "|"
+date_format: 
+default_non_mapped: #True, default False
+header: #True, default False
+enclosing_character: +
+escaping_character: \
+# mapping file mapping.yaml will be used if present in test directory

--- a/mcsimport/test/enclose_5/expected.csv
+++ b/mcsimport/test/enclose_5/expected.csv
@@ -1,0 +1,7 @@
+1,hello world,1
+2,"hello world",2
+3,"hello 
+world",
+4,"hello +world+",4
+5,\,5
+6,\,6

--- a/mcsimport/test/enclose_5/input.csv
+++ b/mcsimport/test/enclose_5/input.csv
@@ -1,0 +1,7 @@
+1|hello world|1
+2|+hello world+|2
+3|+hello 
+world+|
+4|+hello \+world\++|4
+5|\|5
+6|+\\+|6

--- a/mcsimport/test/header_1/DDL.sql
+++ b/mcsimport/test/header_1/DDL.sql
@@ -1,0 +1,1 @@
+CREATE TABLE IF NOT EXISTS mcsimport_test_header_1 (id int, v varchar(16), i2 int) engine=columnstore

--- a/mcsimport/test/header_1/config.yaml
+++ b/mcsimport/test/header_1/config.yaml
@@ -1,0 +1,17 @@
+# required test parameter
+name: tests if the header line is ignored
+expected_exit_value: 0
+
+# required mcsimport command line paramter
+table: mcsimport_test_header_1
+# database is defined by test.py
+# input file input.csv will be used if present in test directory
+
+# optional mcsimport command line parameter
+delimiter: 
+date_format: 
+default_non_mapped: #True, default False
+header: True #True, default False
+enclosing_character: 
+escaping_character: 
+# mapping file mapping.yaml will be used if present in test directory

--- a/mcsimport/test/header_1/expected.csv
+++ b/mcsimport/test/header_1/expected.csv
@@ -1,0 +1,5 @@
+1,hello world,1
+2,"hello world",2
+3,"hello 
+world",
+4,"hello ""world""",4

--- a/mcsimport/test/header_1/input.csv
+++ b/mcsimport/test/header_1/input.csv
@@ -1,0 +1,6 @@
+id,text,id2
+1,hello world,1
+2,"hello world",2
+3,"hello 
+world",
+4,"hello ""world""",4

--- a/mcsimport/test/test.py
+++ b/mcsimport/test/test.py
@@ -154,6 +154,12 @@ def loadTestConfig(test_directory):
             raise Exception("test's coverage value: %s is invalid" %(validation_coverage,))
     else:
         testConfig["validation_coverage"] = None
+    if not "header" in testConfig:
+        testConfig["header"] = False
+    if not "enclosing_character" in testConfig:
+        testConfig["enclosing_character"] = None
+    if not "escaping_character" in testConfig:
+        testConfig["escaping_character"] = None
     return testConfig
     
 # executes the SQL statements of given file to set up the test table
@@ -207,6 +213,14 @@ def executeMcsimport(test_directory,testConfig):
         cmd.append("%s" % (testConfig["date_format"],))
     if testConfig["default_non_mapped"]:
         cmd.append("-default_non_mapped")
+    if testConfig["header"]:
+        cmd.append("-header")
+    if testConfig["enclosing_character"] is not None:
+        cmd.append("-E")
+        cmd.append("%s" % (testConfig["enclosing_character"]))
+    if testConfig["escaping_character"] is not None:
+        cmd.append("-C")
+        cmd.append("%s" % (testConfig["escaping_character"]))
     
     print("Execute mcsimport: %s" % (cmd,))
     try:
@@ -236,7 +250,7 @@ def validateInjection(test_directory,table,validationCoverage):
         # validate that the number of rows of expected.csv and target table match
         cursor.execute("SELECT COUNT(*) AS cnt FROM %s" % (table,))
         cnt = cursor.fetchone()[0]
-        num_lines = sum(1 for line in open(os.path.realpath(os.path.join(test_directory,"expected.csv"))))
+        num_lines = len(list(csv.reader(open(os.path.join(test_directory,"expected.csv")))))
         assert num_lines == cnt, "the number of injected rows: %d doesn't match the number of expected rows: %d" % (cnt, num_lines)
         # validate that each input line in expected.csv was injected into the target table
         if validationCoverage != 0:
@@ -289,3 +303,4 @@ def cleanUpColumnstoreTable(table):
     
 # execute the test suite
 executeTestSuite()
+

--- a/mcsimport/test/test.py
+++ b/mcsimport/test/test.py
@@ -250,7 +250,11 @@ def validateInjection(test_directory,table,validationCoverage):
         # validate that the number of rows of expected.csv and target table match
         cursor.execute("SELECT COUNT(*) AS cnt FROM %s" % (table,))
         cnt = cursor.fetchone()[0]
-        num_lines = len(list(csv.reader(open(os.path.join(test_directory,"expected.csv")))))
+        num_lines = 0
+        with open(os.path.join(test_directory,"expected.csv")) as csv_file:
+            csv_reader = csv.reader(csv_file, delimiter=',')
+            for line in csv_reader:
+                num_lines = num_lines+1
         assert num_lines == cnt, "the number of injected rows: %d doesn't match the number of expected rows: %d" % (cnt, num_lines)
         # validate that each input line in expected.csv was injected into the target table
         if validationCoverage != 0:


### PR DESCRIPTION
- the input csv file supports now enclose and escape characters
- an optional header parameter was introduced to ignore the first csv line as header if set
- csv input format compatibility with RFC4180 achieved
- tests have been added to the regression suite
- documentation in Github has been updated with new command line parameters